### PR TITLE
Improve planner interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# TEST - Création d'une application de révision
+# Application de révision
+
+Cette application Web permet d'enregistrer des leçons et de planifier les dates de révision. Les données sont stockées localement dans le navigateur via `localStorage`.
+
+## Lancer l'application
+
+1. Ouvrir `index.html` dans un navigateur moderne.
+2. Ajouter des leçons via le formulaire (titre, matière, description, date de première révision, taux d'apprentissage en jours).
+3. Les leçons apparaissent dans le calendrier. Vous pouvez afficher la vue semaine ou mois et naviguer grâce aux boutons.
+4. Chaque journée peut contenir jusqu'à dix leçons. Lorsqu'une leçon est révisée, une fenêtre propose quatre choix d’évaluation. Selon votre réponse, la nouvelle date est calculée par `date actuelle + k^n` où `n` est le taux d'apprentissage (augmenté de 1) et `k` vaut 1.2, 1, 0.5 ou 0.01.
+5. Les leçons peuvent être modifiées, y compris leur taux d'apprentissage, via le bouton **Modifier**.
+6. Un onglet **Statistiques** affiche le nombre total de leçons, leur taux d'apprentissage moyen et un histogramme du nombre de révisions.
+7. L'onglet **Tâches** (sélectionné par défaut) permet d'organiser sa journée avec une liste de choses à faire. Chaque tâche possède un minuteur (bouton Play/Stop) qui incrémente automatiquement le temps réalisé.
+
+Aucune installation supplémentaire n'est requise.
+L'interface est basée sur Bootstrap pour un rendu plus agréable.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,228 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Révision Planner</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1 class="text-center bg-success text-white py-2">Révision Planner</h1>
+
+    <div class="container my-4">
+        <ul class="nav nav-tabs mb-3" id="mainTabs" role="tablist">
+            <li class="nav-item" role="presentation">
+                <button class="nav-link active" id="tasks-tab" data-bs-toggle="tab" data-bs-target="#tasks" type="button" role="tab">Tâches</button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button class="nav-link" id="planning-tab" data-bs-toggle="tab" data-bs-target="#planning" type="button" role="tab">Planning</button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button class="nav-link" id="stats-tab" data-bs-toggle="tab" data-bs-target="#stats" type="button" role="tab">Statistiques</button>
+            </li>
+        </ul>
+        <div class="tab-content">
+            <div class="tab-pane fade show active" id="tasks" role="tabpanel">
+                <section class="mb-4" id="tasks-section">
+                    <h2>Organisation quotidienne</h2>
+                    <form id="task-form" class="row g-3 mb-3">
+                        <div class="col-md-4">
+                            <label class="form-label">Titre
+                                <input type="text" id="task-title" class="form-control" required>
+                            </label>
+                        </div>
+                        <div class="col-md-4">
+                            <label class="form-label">Matière
+                                <input type="text" id="task-subject" class="form-control" required>
+                            </label>
+                        </div>
+                        <div class="col-md-4">
+                            <label class="form-label">Date de début
+                                <input type="date" id="task-start" class="form-control" required>
+                            </label>
+                        </div>
+                        <div class="col-12">
+                            <label class="form-label">Description
+                                <textarea id="task-desc" class="form-control" required></textarea>
+                            </label>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">Temps prévu (min)
+                                <input type="number" id="task-expected" class="form-control" min="1" required>
+                            </label>
+                        </div>
+                        <div class="col-12">
+                            <button type="submit" class="btn btn-primary">Ajouter</button>
+                        </div>
+                    </form>
+                    <div id="tasks-container" class="list-group"></div>
+                </section>
+            </div>
+            <div class="tab-pane fade" id="planning" role="tabpanel">
+                <section id="calendar" class="mb-4">
+                    <div class="d-flex justify-content-between align-items-center mb-3">
+                        <button id="prev" class="btn btn-secondary">Précédent</button>
+                        <span id="current-period" class="fw-bold"></span>
+                        <div>
+                            <button id="next" class="btn btn-secondary me-2">Suivant</button>
+                            <button id="toggle-view" class="btn btn-outline-primary">Changer de vue</button>
+                        </div>
+                    </div>
+                    <div id="calendar-grid"></div>
+                </section>
+
+                <section id="add-lesson" class="card p-3">
+                    <h2>Ajouter une leçon</h2>
+                    <form id="lesson-form" class="row g-3">
+                        <div class="col-md-6">
+                            <label class="form-label">Titre
+                                <input type="text" class="form-control" id="title" required>
+                            </label>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">Matière
+                                <input type="text" class="form-control" id="subject" required>
+                            </label>
+                        </div>
+                        <div class="col-12">
+                            <label class="form-label">Description
+                                <textarea id="description" class="form-control" required></textarea>
+                            </label>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">Date de première révision
+                                <input type="date" class="form-control" id="date" required>
+                            </label>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">Taux d'apprentissage (en jours)
+                                <input type="number" class="form-control" id="learningRate" min="1" value="1" required>
+                            </label>
+                        </div>
+                        <div class="col-12">
+                            <button type="submit" class="btn btn-primary">Ajouter</button>
+                        </div>
+                    </form>
+                </section>
+            </div>
+            <div class="tab-pane fade" id="stats" role="tabpanel">
+                <h2 class="mt-3">Statistiques</h2>
+                <canvas id="stats-chart" height="200"></canvas>
+                <ul class="list-group mt-3">
+                    <li class="list-group-item">Total leçons : <span id="stats-total"></span></li>
+                    <li class="list-group-item">Taux d'apprentissage moyen : <span id="stats-average"></span></li>
+                </ul>
+            </div>
+        </div>
+    </div>
+
+    <!-- Modal d'évaluation de la révision -->
+    <div class="modal fade" id="reviewModal" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Comment s'est passée la révision ?</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="d-grid gap-2">
+                        <button class="btn btn-success review-choice" data-value="1.2">Bien révisé</button>
+                        <button class="btn btn-primary review-choice" data-value="1">Révision correcte</button>
+                        <button class="btn btn-warning review-choice" data-value="0.5">Révision imparfaite</button>
+                        <button class="btn btn-danger review-choice" data-value="0.01">Très mal révisé</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Modal d'édition -->
+    <div class="modal fade" id="editModal" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Modifier la leçon</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <form id="edit-form" class="modal-body row g-3">
+                    <div class="col-12">
+                        <label class="form-label">Titre
+                            <input type="text" id="edit-title" class="form-control" required>
+                        </label>
+                    </div>
+                    <div class="col-12">
+                        <label class="form-label">Matière
+                            <input type="text" id="edit-subject" class="form-control" required>
+                        </label>
+                    </div>
+                    <div class="col-12">
+                        <label class="form-label">Description
+                            <textarea id="edit-description" class="form-control" required></textarea>
+                        </label>
+                    </div>
+                    <div class="col-12">
+                        <label class="form-label">Date de révision
+                            <input type="date" id="edit-date" class="form-control" required>
+                        </label>
+                    </div>
+                    <div class="col-12">
+                        <label class="form-label">Taux d'apprentissage
+                            <input type="number" id="edit-rate" class="form-control" min="1" required>
+                        </label>
+                    </div>
+                    <div class="col-12">
+                        <button type="submit" class="btn btn-primary">Enregistrer</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <!-- Modal d'édition de tâche -->
+    <div class="modal fade" id="taskEditModal" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Modifier la tâche</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <form id="task-edit-form" class="modal-body row g-3">
+                    <div class="col-12">
+                        <label class="form-label">Titre
+                            <input type="text" id="task-edit-title" class="form-control" required>
+                        </label>
+                    </div>
+                    <div class="col-12">
+                        <label class="form-label">Matière
+                            <input type="text" id="task-edit-subject" class="form-control" required>
+                        </label>
+                    </div>
+                    <div class="col-12">
+                        <label class="form-label">Description
+                            <textarea id="task-edit-desc" class="form-control" required></textarea>
+                        </label>
+                    </div>
+                    <div class="col-12">
+                        <label class="form-label">Temps prévu (min)
+                            <input type="number" id="task-edit-expected" class="form-control" min="1" required>
+                        </label>
+                    </div>
+                    <div class="col-12">
+                        <label class="form-label">Date de début
+                            <input type="date" id="task-edit-start" class="form-control" required>
+                        </label>
+                    </div>
+                    <div class="col-12">
+                        <button type="submit" class="btn btn-primary">Enregistrer</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,339 @@
+const form = document.getElementById('lesson-form');
+const calendarGrid = document.getElementById('calendar-grid');
+const currentPeriod = document.getElementById('current-period');
+const prevBtn = document.getElementById('prev');
+const nextBtn = document.getElementById('next');
+const toggleViewBtn = document.getElementById('toggle-view');
+const reviewModal = new bootstrap.Modal(document.getElementById('reviewModal'));
+const editModal = new bootstrap.Modal(document.getElementById('editModal'));
+const taskEditModal = new bootstrap.Modal(document.getElementById('taskEditModal'));
+const reviewButtons = document.querySelectorAll('.review-choice');
+const editForm = document.getElementById('edit-form');
+const statsTotal = document.getElementById('stats-total');
+const statsAverage = document.getElementById('stats-average');
+const taskForm = document.getElementById('task-form');
+const tasksContainer = document.getElementById('tasks-container');
+const taskEditForm = document.getElementById('task-edit-form');
+const statsChartCanvas = document.getElementById('stats-chart');
+
+let currentReviewId = null;
+let currentEditId = null;
+let currentTaskEditId = null;
+
+let tasks = JSON.parse(localStorage.getItem('tasks') || '[]');
+let timers = {};
+let history = JSON.parse(localStorage.getItem('history') || '[]');
+let statsChart = null;
+
+let lessons = JSON.parse(localStorage.getItem('lessons') || '[]');
+let currentDate = new Date();
+let view = 'month'; // or 'week'
+
+function saveLessons() {
+    localStorage.setItem('lessons', JSON.stringify(lessons));
+}
+
+function saveTasks() {
+    localStorage.setItem('tasks', JSON.stringify(tasks));
+}
+
+function saveHistory() {
+    localStorage.setItem('history', JSON.stringify(history));
+}
+
+function renderStats() {
+    statsTotal.textContent = lessons.length;
+    const avg = lessons.length ? lessons.reduce((s, l) => s + l.rate, 0) / lessons.length : 0;
+    statsAverage.textContent = avg.toFixed(2);
+
+    const sorted = history.slice().sort((a,b) => a.date.localeCompare(b.date));
+    const labels = sorted.map(h => h.date);
+    const values = sorted.map(h => h.count);
+    if (statsChart) {
+        statsChart.data.labels = labels;
+        statsChart.data.datasets[0].data = values;
+        statsChart.update();
+    } else if (statsChartCanvas) {
+        statsChart = new Chart(statsChartCanvas, {
+            type: 'bar',
+            data: { labels, datasets: [{ label: 'Révisions', data: values, backgroundColor: '#0d6efd' }] },
+            options: { scales: { y: { beginAtZero: true } } }
+        });
+    }
+}
+
+function renderTasks() {
+    tasksContainer.innerHTML = '';
+    tasks.forEach(t => {
+        const item = document.createElement('div');
+        item.className = 'list-group-item d-flex align-items-center';
+        const ratio = document.createElement('span');
+        ratio.className = 'me-2';
+        ratio.textContent = `${Math.floor(t.actual/60)}/${t.expected} min`;
+        const validate = document.createElement('button');
+        validate.className = 'btn btn-success btn-sm me-2';
+        validate.textContent = 'Valider';
+        validate.onclick = () => { t.done = true; saveTasks(); renderTasks(); };
+        const play = document.createElement('button');
+        play.className = 'btn btn-secondary btn-sm ms-auto me-2';
+        play.textContent = timers[t.id] ? 'Stop' : 'Play';
+        play.onclick = () => toggleTimer(t.id);
+        const editBtn = document.createElement('button');
+        editBtn.className = 'btn btn-outline-secondary btn-sm';
+        editBtn.textContent = 'Modifier';
+        editBtn.onclick = () => openTaskEdit(t.id);
+        item.appendChild(ratio);
+        item.appendChild(validate);
+        item.appendChild(play);
+        item.appendChild(editBtn);
+        const info = document.createElement('span');
+        info.className = 'ms-2 flex-grow-1';
+        info.textContent = `${t.title} (${t.subject})`;
+        item.appendChild(info);
+        if (t.done) item.classList.add('opacity-50');
+        tasksContainer.appendChild(item);
+    });
+}
+
+taskForm?.addEventListener('submit', e => {
+    e.preventDefault();
+    const task = {
+        id: Date.now(),
+        title: document.getElementById('task-title').value,
+        subject: document.getElementById('task-subject').value,
+        description: document.getElementById('task-desc').value,
+        expected: parseInt(document.getElementById('task-expected').value,10),
+        actual: 0,
+        done: false,
+        start: document.getElementById('task-start').value
+    };
+    tasks.push(task);
+    saveTasks();
+    taskForm.reset();
+    renderTasks();
+});
+
+function openTaskEdit(id) {
+    const t = tasks.find(ts => ts.id === id);
+    if (!t) return;
+    currentTaskEditId = id;
+    document.getElementById('task-edit-title').value = t.title;
+    document.getElementById('task-edit-subject').value = t.subject;
+    document.getElementById('task-edit-desc').value = t.description;
+    document.getElementById('task-edit-expected').value = t.expected;
+    document.getElementById('task-edit-start').value = t.start;
+    taskEditModal.show();
+}
+
+taskEditForm?.addEventListener('submit', e => {
+    e.preventDefault();
+    const t = tasks.find(ts => ts.id === currentTaskEditId);
+    if (!t) return;
+    t.title = document.getElementById('task-edit-title').value;
+    t.subject = document.getElementById('task-edit-subject').value;
+    t.description = document.getElementById('task-edit-desc').value;
+    t.expected = parseInt(document.getElementById('task-edit-expected').value,10);
+    t.start = document.getElementById('task-edit-start').value;
+    saveTasks();
+    taskEditModal.hide();
+    renderTasks();
+});
+
+function toggleTimer(id) {
+    if (timers[id]) {
+        clearInterval(timers[id]);
+        delete timers[id];
+    } else {
+        timers[id] = setInterval(() => {
+            const t = tasks.find(ts => ts.id === id);
+            if (t) {
+                t.actual += 1;
+                saveTasks();
+                renderTasks();
+            }
+        }, 1000);
+    }
+    renderTasks();
+}
+
+form.addEventListener('submit', e => {
+    e.preventDefault();
+    const dateVal = document.getElementById('date').value;
+    if (getLessonsForDay(dateVal).length >= 10) {
+        alert('Maximum de leçons atteint pour ce jour');
+        return;
+    }
+    const lesson = {
+        id: Date.now(),
+        title: document.getElementById('title').value,
+        subject: document.getElementById('subject').value,
+        description: document.getElementById('description').value,
+        nextReview: dateVal,
+        rate: parseInt(document.getElementById('learningRate').value, 10)
+    };
+    lessons.push(lesson);
+    saveLessons();
+    form.reset();
+    renderCalendar();
+    renderStats();
+});
+
+function getLessonsForDay(dateStr) {
+    return lessons.filter(l => l.nextReview === dateStr);
+}
+
+function addDays(date, days) {
+    const result = new Date(date);
+    result.setDate(result.getDate() + days);
+    return result;
+}
+
+function markReviewed(id) {
+    currentReviewId = id;
+    reviewModal.show();
+}
+
+reviewButtons.forEach(btn => {
+    btn.addEventListener('click', () => {
+        const k = parseFloat(btn.getAttribute('data-value'));
+        const lesson = lessons.find(l => l.id === currentReviewId);
+        if (lesson) {
+            lesson.rate += 1;
+            const n = lesson.rate;
+            const days = Math.ceil(Math.pow(k, n));
+            lesson.nextReview = addDays(new Date(), days).toISOString().slice(0,10);
+            const today = new Date().toISOString().slice(0,10);
+            const rec = history.find(h => h.date === today);
+            if (rec) rec.count += 1; else history.push({date: today, count:1});
+            saveHistory();
+            saveLessons();
+            renderCalendar();
+            renderStats();
+        }
+        reviewModal.hide();
+    });
+});
+
+function openEdit(id) {
+    const lesson = lessons.find(l => l.id === id);
+    if (!lesson) return;
+    currentEditId = id;
+    document.getElementById('edit-title').value = lesson.title;
+    document.getElementById('edit-subject').value = lesson.subject;
+    document.getElementById('edit-description').value = lesson.description;
+    document.getElementById('edit-date').value = lesson.nextReview;
+    document.getElementById('edit-rate').value = lesson.rate;
+    editModal.show();
+}
+
+editForm.addEventListener('submit', e => {
+    e.preventDefault();
+    const lesson = lessons.find(l => l.id === currentEditId);
+    if (!lesson) return;
+    const newDate = document.getElementById('edit-date').value;
+    if (lesson.nextReview !== newDate && getLessonsForDay(newDate).length >= 10) {
+        alert('Maximum de leçons atteint pour ce jour');
+        return;
+    }
+    lesson.title = document.getElementById('edit-title').value;
+    lesson.subject = document.getElementById('edit-subject').value;
+    lesson.description = document.getElementById('edit-description').value;
+    lesson.nextReview = newDate;
+    lesson.rate = parseInt(document.getElementById('edit-rate').value, 10);
+    saveLessons();
+    editModal.hide();
+    renderCalendar();
+    renderStats();
+});
+
+function renderCalendar() {
+    calendarGrid.innerHTML = '';
+    calendarGrid.classList.toggle('week-view', view === 'week');
+    calendarGrid.classList.toggle('month-view', view === 'month');
+    const year = currentDate.getFullYear();
+    const month = currentDate.getMonth();
+    const start = new Date(year, month, 1);
+
+    let startDay = start.getDay();
+    if (startDay === 0) startDay = 7; // make Monday first
+
+    let daysInMonth = new Date(year, month + 1, 0).getDate();
+
+    let days = [];
+    if (view === 'week') {
+        // start from Monday of current week
+        const day = new Date(currentDate);
+        const diff = day.getDay() === 0 ? -6 : 1 - day.getDay();
+        const monday = addDays(day, diff);
+        for (let i = 0; i < 7; i++) {
+            const d = addDays(monday, i);
+            days.push(d);
+        }
+        currentPeriod.textContent = `Semaine du ${monday.toLocaleDateString()}`;
+    } else {
+        // month view
+        for (let i = 1; i <= daysInMonth; i++) {
+            days.push(new Date(year, month, i));
+        }
+        currentPeriod.textContent = `${currentDate.toLocaleDateString('fr-FR', { month: 'long', year: 'numeric' })}`;
+    }
+
+    days.forEach(d => {
+        const dateStr = d.toISOString().slice(0,10);
+        const dayDiv = document.createElement('div');
+        dayDiv.className = 'day col border p-1';
+        const header = document.createElement('div');
+        header.className = 'day-header fw-bold';
+        header.textContent = d.getDate();
+        dayDiv.appendChild(header);
+
+        const ls = getLessonsForDay(dateStr);
+        ls.forEach(l => {
+            const div = document.createElement('div');
+            div.className = 'lesson bg-light border-start border-primary ps-1 mb-1 small';
+            div.textContent = `${l.title} (${l.subject}) `;
+            const revBtn = document.createElement('button');
+            revBtn.className = 'btn btn-sm btn-success ms-1';
+            revBtn.textContent = 'Révisé';
+            revBtn.onclick = () => markReviewed(l.id);
+            const editBtn = document.createElement('button');
+            editBtn.className = 'btn btn-sm btn-outline-secondary ms-1';
+            editBtn.textContent = 'Modifier';
+            editBtn.onclick = () => openEdit(l.id);
+            div.appendChild(revBtn);
+            div.appendChild(editBtn);
+            dayDiv.appendChild(div);
+        });
+
+        calendarGrid.appendChild(dayDiv);
+    });
+    renderStats();
+}
+
+prevBtn.addEventListener('click', () => {
+    if (view === 'week') {
+        currentDate = addDays(currentDate, -7);
+    } else {
+        currentDate.setMonth(currentDate.getMonth() - 1);
+    }
+    renderCalendar();
+});
+
+nextBtn.addEventListener('click', () => {
+    if (view === 'week') {
+        currentDate = addDays(currentDate, 7);
+    } else {
+        currentDate.setMonth(currentDate.getMonth() + 1);
+    }
+    renderCalendar();
+});
+
+toggleViewBtn.addEventListener('click', () => {
+    view = view === 'week' ? 'month' : 'week';
+    renderCalendar();
+});
+
+// initial render
+renderCalendar();
+renderStats();
+renderTasks();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,33 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background: #f4f4f4;
+}
+
+#calendar-grid {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 5px;
+    height: 500px;
+    overflow-y: auto;
+}
+
+.day {
+    min-height: 80px;
+}
+
+.month-view .day {
+    max-height: 110px;
+    overflow-y: auto;
+}
+
+.week-view .day {
+    height: auto;
+}
+
+.lesson {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}


### PR DESCRIPTION
## Summary
- move lesson form below calendar in a tabbed interface
- make calendar height fixed with scrollable month cells
- allow editing of learning rate
- show basic statistics for lessons
- add tasks tab with timers and edit modal
- display review history histogram

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866aa8d1ea0833096b6c71fbddcac80